### PR TITLE
fix: Add the Origin field to the http headers

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ const headers = {
     "Sec-Ch-Ua-Mobile": "?0",
     "Sec-Ch-Ua-Platform": '"Windows"',
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+    "Origin": "chrome-extension://ekbbplmjjgoobhdlffmgeokalelnmjjc"
 }
 
 function readFile(pathFile) {


### PR DESCRIPTION
Without the correct Origin field, generating the token will fail.